### PR TITLE
Update readme.md: Translation section

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -39,6 +39,16 @@ CMD + K
 CTRL + /  
 CMD + /  
 
+## Translation
+
+To translate or edit the default placeholder, you have to publish the translation file for *wire-element/spotlight*: 
+
+```php
+php artisan vendor:publish --tag=livewire-ui-spotlight-translations
+```
+
+
+
 ## Contributing
 
 If you want to contribute to this packages, you may want to test it in a real Filament project:


### PR DESCRIPTION
Add instructions to publish the translation file.

I was going to PR a localization option, but then realized it's already there on the underlying package wire-element/spotlight.

Might come in handy for international users!