### PR TITLE
filament-companies route params fixed

### DIFF
--- a/src/Actions/RegisterPages.php
+++ b/src/Actions/RegisterPages.php
@@ -2,6 +2,8 @@
 
 namespace pxlrbt\FilamentSpotlight\Actions;
 
+use Wallo\FilamentCompanies\FilamentCompanies;
+use Illuminate\Support\Facades\Auth;
 use Filament\Facades\Filament;
 use LivewireUI\Spotlight\Spotlight;
 use pxlrbt\FilamentSpotlight\Commands\PageCommand;

--- a/src/Actions/RegisterPages.php
+++ b/src/Actions/RegisterPages.php
@@ -14,7 +14,11 @@ class RegisterPages
 
         foreach ($pages as $page) {
             $name = \Livewire\invade(new $page())->getTitle();
-            $url = $page::getUrl();
+            if (str_contains('Wallo\FilamentCompanies\Pages\Companies\CompanySettings', $page) && FilamentCompanies::hasCompanyFeatures()) {
+                $url = $page::getUrl([Auth::user()?->currentCompany]);
+            } else {
+                $url = $page::getUrl();
+            }
 
             if (blank($name) || blank($url)) {
                 continue;

--- a/src/Actions/RegisterPages.php
+++ b/src/Actions/RegisterPages.php
@@ -2,8 +2,6 @@
 
 namespace pxlrbt\FilamentSpotlight\Actions;
 
-use Wallo\FilamentCompanies\FilamentCompanies;
-use Illuminate\Support\Facades\Auth;
 use Filament\Facades\Filament;
 use LivewireUI\Spotlight\Spotlight;
 use pxlrbt\FilamentSpotlight\Commands\PageCommand;
@@ -16,8 +14,10 @@ class RegisterPages
 
         foreach ($pages as $page) {
             $name = \Livewire\invade(new $page())->getTitle();
-            if (str_contains('Wallo\FilamentCompanies\Pages\Companies\CompanySettings', $page) && FilamentCompanies::hasCompanyFeatures()) {
-                $url = $page::getUrl([Auth::user()?->currentCompany]);
+            if (str_contains('Wallo\FilamentCompanies\Pages\Companies\CompanySettings', $page)) {
+                if (@\Wallo\FilamentCompanies\FilamentCompanies::hasCompanyFeatures()) {
+                    $url = $page::getUrl([@\Illuminate\Support\Facades\Auth::user()?->currentCompany]);                    
+                }
             } else {
                 $url = $page::getUrl();
             }


### PR DESCRIPTION
Missing required parameter for [Route: filament.pages.companies/{company}] [URI: companies/{company}] [Missing parameter: company].

This packages https://github.com/andrewdwallo/filament-companies