### PR TITLE
Fix: return value must be of type string, null returned

### DIFF
--- a/src/Actions/RegisterUserMenu.php
+++ b/src/Actions/RegisterUserMenu.php
@@ -35,7 +35,7 @@ class RegisterUserMenu
         }
     }
 
-    protected function getName(string $key, MenuItem $item): string
+    protected function getName(string $key, MenuItem $item): ?string
     {
         return match ($key) {
             'account' => $item->getLabel() ?? __('Your Account'),


### PR DESCRIPTION
Fixes a problem when adding

```php
'profile' => MenuItem::make()
    ->url(fn (): string => ViewProfile::getUrl()),
```

which will return null and cause `Return value must be of type string, null returned` error to occur.