### PR TITLE
ignore pages with parameters

### DIFF
--- a/src/Actions/RegisterPages.php
+++ b/src/Actions/RegisterPages.php
@@ -20,6 +20,10 @@ class RegisterPages
              */
             $page = new $pageClass();
 
+            if (self::hasParameters($page::getSlug())) {
+                continue;
+            }
+
             if (method_exists($page, 'shouldRegisterSpotlight') && $page::shouldRegisterSpotlight() === false) {
                 continue;
             }
@@ -42,5 +46,10 @@ class RegisterPages
 
             Spotlight::$commands[$command->getId()] = $command;
         }
+    }
+
+    private static function hasParameters(string $slug): bool
+    {
+        return preg_match('/{[^}]+}/', $slug) === 1;
     }
 }


### PR DESCRIPTION
**Problem:** if you have a Filament page with a parameter like this `protected static ?string $slug = 'test/{parameter}';` it will break the plugin. Even if you set shouldRegisterSpotlight to false in your page.

**Solution:** this code just ignores all pages with parameters

Discord user jamiecee20 brought this to my attention as it breaks my plugin (https://discord.com/channels/883083792112300104/1252364577228853389)