### PR TITLE
fix: use `getRouteKey` for resource page

### DIFF
--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -110,7 +110,7 @@ class ResourceCommand extends SpotlightCommand
             ->limit(50)
             ->get()
             ->map(fn (Model $record) => new SpotlightSearchResult(
-                $record->getKey(),
+                $record->getRouteKey(),
                 $resource::getGlobalSearchResultTitle($record),
                 collect($resource::getGlobalSearchResultDetails($record))
                     ->map(fn ($value, $key) => $key.': '.$value)


### PR DESCRIPTION
Fixes #31

Use `getRouteKey` for navigating to resource