### PR TITLE
Skip plugin when not logged in.

### DIFF
--- a/src/SpotlightPlugin.php
+++ b/src/SpotlightPlugin.php
@@ -36,6 +36,9 @@ class SpotlightPlugin implements Plugin
 
     public function boot(Panel $panel): void
     {
+        if(!Filament::auth()->check()) {
+            return;
+        }
         Filament::serving(function () use ($panel) {
             config()->set('livewire-ui-spotlight.include_js', false);
 


### PR DESCRIPTION
On filament 4 it seems to try to load the user menu even if not logged in. This pull fixes that.