### PR TITLE
Skip plugin when not logged in

### DIFF
--- a/src/SpotlightPlugin.php
+++ b/src/SpotlightPlugin.php
@@ -37,6 +37,9 @@ class SpotlightPlugin implements Plugin
     public function boot(Panel $panel): void
     {
         Filament::serving(function () use ($panel) {
+            if(!Filament::auth()->check()) {
+                return;
+            }
             config()->set('livewire-ui-spotlight.include_js', false);
 
             if (Filament::hasTenancy()) {


### PR DESCRIPTION
Sometimes, on my filament 4 test the plugin will try to load itself when the user is not logged in. This pull will prevent that from happening.