### PR TITLE
Support enum NavigationGroup

### DIFF
--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -49,7 +49,7 @@ class ResourceCommand extends SpotlightCommand
     public function getName(): string
     {
         return collect([
-            $this->resource::getNavigationGroup(),
+            ($group = $this->resource::getNavigationGroup()) instanceof HasLabel ? $group->getLabel() : $group,
             $this->resource::getBreadcrumb(),
             $this->page::getNavigationLabel(),
         ])


### PR DESCRIPTION
Since Filament v4 we can [register Navigation Groups using Enums](https://filamentphp.com/docs/4.x/navigation/overview#registering-navigation-groups-with-an-enum).

If you use this feature with spotlight, then the rendering breaks because it cannot `implode(SomeEnum::Case, 'normal string')`.
This PR fixes this behaviour.