### PR TITLE
Fix HasLabel import for resource command names

### DIFF
--- a/src/Commands/ResourceCommand.php
+++ b/src/Commands/ResourceCommand.php
@@ -8,6 +8,7 @@ use Filament\Resources\Pages\ManageRelatedRecords;
 use Filament\Resources\Pages\Page;
 use Filament\Resources\Pages\ViewRecord;
 use Filament\Resources\Resource;
+use Filament\Support\Contracts\HasLabel;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;


### PR DESCRIPTION
## Summary
  - import `Filament\Support\Contracts\HasLabel` in `ResourceCommand`
  - allow the `instanceof HasLabel` check in `getName()` to run so navigation enums provide their labels

  ## Testing
  - composer test
